### PR TITLE
Support for cook data

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cgla_case_chart_assister (0.1.0)
+    cgla_case_chart_assister (0.1.1)
       pdf-forms (~> 1.2)
       roo (~> 2.8)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     pdf-forms (1.2.0)
       cliver (~> 0.3.2)
       safe_shell (>= 1.0.3, < 2.0)
-    rake (10.5.0)
+    rake (13.0.1)
     roo (2.8.3)
       nokogiri (~> 1)
       rubyzip (>= 1.3.0, < 3.0.0)
@@ -42,7 +42,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.17)
   cgla_case_chart_assister!
-  rake (~> 10.0)
+  rake (>= 12.3.3)
   rspec (~> 3.0)
 
 BUNDLED WITH

--- a/bin/fill_pdf
+++ b/bin/fill_pdf
@@ -90,7 +90,7 @@ Dir.glob("*.csv", base: path_to_directory) do |filename|
 
   case_chart_header_data = { client_name: history.person_name, IR_number: history.ir_number, dob: history.dob }
 
-  court_event_history = history.events.filter {|event| event.type == :charge}
+  court_event_history = history.events.filter {|event| event.is_a?(CglaCaseChartAssister::Charge) }
 
   sorted_court_history = court_event_history.sort_by do |e|
     final_disposition = e.dispositions.first

--- a/cgla_case_chart_assister.gemspec
+++ b/cgla_case_chart_assister.gemspec
@@ -41,6 +41,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pdf-forms", "~> 1.2"
   spec.add_dependency "roo", "~> 2.8"
   spec.add_development_dependency "bundler", "~> 1.17"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/cgla_case_chart_assister.rb
+++ b/lib/cgla_case_chart_assister.rb
@@ -11,10 +11,6 @@ require 'cgla_case_chart_assister/models/court_case'
 require 'cgla_case_chart_assister/models/disposition'
 require 'cgla_case_chart_assister/models/history'
 
-# Constants
-require 'cgla_case_chart_assister/constants/disqualified_code_sections'
-require 'cgla_case_chart_assister/constants/offense_classes'
-
 # Eligibility Flows
 require 'cgla_case_chart_assister/eligibility_flows/illinois_eligibility_flow'
 

--- a/lib/cgla_case_chart_assister/models/arrest.rb
+++ b/lib/cgla_case_chart_assister/models/arrest.rb
@@ -1,24 +1,8 @@
 require 'cgla_case_chart_assister/constants/disqualified_code_sections'
+require 'cgla_case_chart_assister/models/event'
 
 module CglaCaseChartAssister
-  Arrest = Struct.new(
-    :index,
-    :central_booking_number,
-    :case_number,
-    :date_filed,
-    :arresting_agency_code,
-    :dcn,
-    :code,
-    :description,
-    :offense_type,
-    :offense_class,
-    :dispositions,
-    keyword_init: true) do
-
-    def type
-      :arrest
-    end
-
+  class Arrest < Event
     def pending_case?
       false
     end

--- a/lib/cgla_case_chart_assister/models/charge.rb
+++ b/lib/cgla_case_chart_assister/models/charge.rb
@@ -1,25 +1,9 @@
 require 'cgla_case_chart_assister/constants/disqualified_code_sections'
+require 'cgla_case_chart_assister/models/event'
 
 module CglaCaseChartAssister
   # A charge only occurs for court cases (not arrests)
-  Charge = Struct.new(
-    :index,
-    :central_booking_number,
-    :case_number,
-    :date_filed,
-    :arresting_agency_code,
-    :dcn,
-    :code,
-    :description,
-    :offense_type,
-    :offense_class,
-    :dispositions,
-    keyword_init: true) do
-
-    def type
-      :charge
-    end
-
+  class Charge < Event
     def pending_case?
       dispositions&.all?{|disposition| disposition.description.nil? && disposition.date.nil? }
     end

--- a/lib/cgla_case_chart_assister/models/court_case.rb
+++ b/lib/cgla_case_chart_assister/models/court_case.rb
@@ -3,15 +3,17 @@ module CglaCaseChartAssister
     def initialize(
       case_number: nil,
       person_name: nil,
+      central_booking_number: nil,
       charges: []
     )
 
       @case_number = case_number
       @person_name = person_name
+      @central_booking_number = central_booking_number
       @charges = charges
     end
 
-    attr_reader :case_number, :person_name, :charges
+    attr_reader :case_number, :person_name, :central_booking_number, :charges
 
     def all_expungable?
       charges.all?(&:eligible_for_expungement?)

--- a/lib/cgla_case_chart_assister/models/court_case.rb
+++ b/lib/cgla_case_chart_assister/models/court_case.rb
@@ -2,14 +2,16 @@ module CglaCaseChartAssister
   class CourtCase
     def initialize(
       case_number: nil,
+      person_name: nil,
       charges: []
     )
 
       @case_number = case_number
+      @person_name = person_name
       @charges = charges
     end
 
-    attr_reader :case_number, :charges
+    attr_reader :case_number, :person_name, :charges
 
     def all_expungable?
       charges.all?(&:eligible_for_expungement?)

--- a/lib/cgla_case_chart_assister/models/court_case.rb
+++ b/lib/cgla_case_chart_assister/models/court_case.rb
@@ -1,19 +1,26 @@
 module CglaCaseChartAssister
-  CourtCase = Struct.new(:case_number, :charges, keyword_init: true) do
-    def type
-      :court_case
+  class CourtCase
+    def initialize(
+      case_number: nil,
+      charges: []
+    )
+
+      @case_number = case_number
+      @charges = charges
     end
 
+    attr_reader :case_number, :charges
+
     def all_expungable?
-      charges.all? {|e| e.eligible_for_expungement?}
+      charges.all?(&:eligible_for_expungement?)
     end
 
     def all_sealable?
-      charges.all? {|e| e.eligible_for_sealing?}
+      charges.all?(&:eligible_for_sealing?)
     end
 
     def cannot_determine_sealing?
-      charges.any? {|e| e.code.nil? || e.code.empty?}
+      charges.any? { |e| e.code.nil? || e.code.empty? }
     end
   end
 end

--- a/lib/cgla_case_chart_assister/models/disposition.rb
+++ b/lib/cgla_case_chart_assister/models/disposition.rb
@@ -1,17 +1,21 @@
-require 'cgla_case_chart_assister/constants/disqualified_code_sections'
-
 module CglaCaseChartAssister
-  Disposition = Struct.new(
-    :case_number,
-    :charge_index,
-    :description,
-    :date,
-    :sentence_description,
-    :sentence_duration,
-    keyword_init: true) do
-
-    def type
-      :disposition
+  class Disposition
+    def initialize(
+      case_number: nil,
+      charge_index: nil,
+      description: nil,
+      date: nil,
+      sentence_description: nil,
+      sentence_duration: nil
+    )
+      @case_number = case_number
+      @charge_index = charge_index
+      @description = description
+      @date = date
+      @sentence_description = sentence_description
+      @sentence_duration = sentence_duration
     end
+
+    attr_reader :case_number, :charge_index, :description, :date, :sentence_description, :sentence_duration
   end
 end

--- a/lib/cgla_case_chart_assister/models/event.rb
+++ b/lib/cgla_case_chart_assister/models/event.rb
@@ -1,0 +1,36 @@
+# An abstract base class for Charge and Arrest
+# Not to be used on its own
+module CglaCaseChartAssister
+  class Event
+    def initialize(
+        index: nil,
+        central_booking_number: nil,
+        case_number: nil,
+        date_filed: nil,
+        arresting_agency_code: nil,
+        dcn: nil,
+        code: nil,
+        description: nil,
+        offense_type: nil,
+        offense_class: nil,
+        dispositions: []
+    )
+
+      @index = index
+      @central_booking_number = central_booking_number
+      @case_number = case_number
+      @date_filed = date_filed
+      @arresting_agency_code = arresting_agency_code
+      @dcn = dcn
+      @code = code
+      @description = description
+      @offense_type = offense_type
+      @offense_class = offense_class
+      @dispositions = dispositions
+    end
+
+    attr_reader :index, :central_booking_number, :case_number, :date_filed,
+                :arresting_agency_code, :dcn, :code, :description, :offense_type,
+                :offense_class, :dispositions
+  end
+end

--- a/lib/cgla_case_chart_assister/models/event.rb
+++ b/lib/cgla_case_chart_assister/models/event.rb
@@ -4,7 +4,6 @@ module CglaCaseChartAssister
   class Event
     def initialize(
         index: nil,
-        central_booking_number: nil,
         case_number: nil,
         date_filed: nil,
         arresting_agency_code: nil,
@@ -17,7 +16,6 @@ module CglaCaseChartAssister
     )
 
       @index = index
-      @central_booking_number = central_booking_number
       @case_number = case_number
       @date_filed = date_filed
       @arresting_agency_code = arresting_agency_code
@@ -29,8 +27,7 @@ module CglaCaseChartAssister
       @dispositions = dispositions
     end
 
-    attr_reader :index, :central_booking_number, :case_number, :date_filed,
-                :arresting_agency_code, :dcn, :code, :description, :offense_type,
-                :offense_class, :dispositions
+    attr_reader :index, :case_number, :date_filed, :arresting_agency_code, :dcn,
+                :code, :description, :offense_type, :offense_class, :dispositions
   end
 end

--- a/lib/cgla_case_chart_assister/models/history.rb
+++ b/lib/cgla_case_chart_assister/models/history.rb
@@ -1,19 +1,24 @@
 module CglaCaseChartAssister
-  History = Struct.new(
-    :person_name,
-    :ir_number,
-    :dob,
-    :events,
-    :court_cases,
-    keyword_init: true
-  ) do
+  class History
+    def initialize(
+      person_name: nil,
+      ir_number: nil,
+      dob: nil,
+      events: [],
+      court_cases: []
+    )
 
-    def type
-      :history
+      @person_name = person_name
+      @ir_number = ir_number
+      @dob = dob
+      @events = events
+      @court_cases = court_cases
     end
 
+    attr_reader :person_name, :ir_number, :dob, :events, :court_cases
+
     def has_pending_case?
-      events.any?{|e| e.pending_case?}
+      events.any?(&:pending_case?)
     end
   end
 end

--- a/lib/cgla_case_chart_assister/parsers/champaign_county_parser.rb
+++ b/lib/cgla_case_chart_assister/parsers/champaign_county_parser.rb
@@ -70,7 +70,7 @@ module CglaCaseChartAssister
 
       def group_by_case_number(events)
         case_number_map = {}
-        events.select {|e| e.type == :charge}.each do |e|
+        events.select {|e| e.is_a?(CglaCaseChartAssister::Charge) }.each do |e|
           if case_number_map[e.case_number].nil?
             case_number_map[e.case_number] = [e]
           else

--- a/lib/cgla_case_chart_assister/parsers/cook_county_parser.rb
+++ b/lib/cgla_case_chart_assister/parsers/cook_county_parser.rb
@@ -31,6 +31,7 @@ module CglaCaseChartAssister
           CourtCase.new(
             case_number: case_details['Case_Number'],
             person_name: parse_name(case_details['Name']),
+            central_booking_number: case_details['CB_Number'],
             charges: parse_charges(case_details['ChargeDetails'], case_number: case_details['Case_Number'])
           )
         end

--- a/lib/cgla_case_chart_assister/parsers/cook_county_parser.rb
+++ b/lib/cgla_case_chart_assister/parsers/cook_county_parser.rb
@@ -17,7 +17,7 @@ module CglaCaseChartAssister
           History.new(ir_number: history_json['IR_number'])
         else
           History.new(
-            person_name: parse_name(case_details[0]['Name']),
+            person_name: court_cases.first.person_name,
             ir_number: history_json['IR_number'],
             dob: Date.parse(case_details[0]['Date_of_Birth']),
             events: all_charges,
@@ -30,6 +30,7 @@ module CglaCaseChartAssister
         case_details_array.map do |case_details|
           CourtCase.new(
             case_number: case_details['Case_Number'],
+            person_name: parse_name(case_details['Name']),
             charges: parse_charges(case_details['ChargeDetails'], case_number: case_details['Case_Number'])
           )
         end

--- a/lib/cgla_case_chart_assister/parsers/cook_county_parser.rb
+++ b/lib/cgla_case_chart_assister/parsers/cook_county_parser.rb
@@ -3,7 +3,6 @@ require 'cgla_case_chart_assister/models/court_case'
 require 'cgla_case_chart_assister/models/disposition'
 require 'cgla_case_chart_assister/models/history'
 require 'cgla_case_chart_assister/constants/offense_classes'
-require 'date'
 
 module CglaCaseChartAssister
   class CookCountyParser
@@ -76,7 +75,7 @@ module CglaCaseChartAssister
             case_number: case_number,
             charge_index: charge_event['Sequence'],
             description: charge_event['Disposition_description'],
-            date: Date.parse(format_disposition_date(charge_event['Disposition_date'])),
+            date: parse_disposition_date(charge_event['Disposition_date']),
             sentence_description: charge_event['Sentence'],
             sentence_duration: charge_event['Sentence_duration']
           )
@@ -84,12 +83,10 @@ module CglaCaseChartAssister
         dispositions
       end
 
-      def format_disposition_date(disposition_date)
-        date_array = disposition_date.split(' ')[0].split('/')
-        year = date_array.pop
-        date_array.reverse!
-        date_array << year
-        date_array.join('-')
+      def parse_disposition_date(disposition_date)
+        return if disposition_date.nil? || disposition_date.empty?
+
+        DateTime.strptime(disposition_date, '%m/%d/%Y %I:%M:%S %p')
       end
     end
   end

--- a/lib/cgla_case_chart_assister/parsers/cook_county_parser.rb
+++ b/lib/cgla_case_chart_assister/parsers/cook_county_parser.rb
@@ -14,13 +14,17 @@ module CglaCaseChartAssister
         court_cases = parse_court_cases(case_details)
         all_charges = court_cases.map(&:charges).flatten
 
-        History.new(
-          person_name: parse_name(case_details[0]['Name']),
-          ir_number: history_json['IR_number'],
-          dob: Date.parse(case_details[0]['Date_of_Birth']),
-          events: all_charges,
-          court_cases: court_cases
-        )
+        if case_details.length.zero?
+          History.new(ir_number: history_json['IR_number'])
+        else
+          History.new(
+            person_name: parse_name(case_details[0]['Name']),
+            ir_number: history_json['IR_number'],
+            dob: Date.parse(case_details[0]['Date_of_Birth']),
+            events: all_charges,
+            court_cases: court_cases
+          )
+        end
       end
 
       def parse_court_cases(case_details_array)

--- a/lib/cgla_case_chart_assister/version.rb
+++ b/lib/cgla_case_chart_assister/version.rb
@@ -1,3 +1,3 @@
 module CglaCaseChartAssister
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/fixtures/cook_county.json
+++ b/spec/fixtures/cook_county.json
@@ -171,6 +171,30 @@
           "Sentence_duration": "0"
         }
       ]
+    },
+    {
+      "Case_Number": "00113380301",
+      "Name": "DOE  JOHN",
+      "Date_of_Birth": "19700103",
+      "Gender": "M ",
+      "RD_Number": "F-11111",
+      "CB_Number": "012345678",
+      "SID_Number": null,
+      "FBI_Number": null,
+      "DFND_Ticket_NBR": null,
+      "ChargeDetails": [
+        {
+          "DCN": "014555555",
+          "Statute": "720-570.0/402-A-10",
+          "Charge": "POSS. CONTROL SUBST - PCP",
+          "Sentence": null,
+          "Sequence": "3",
+          "Degree": "Class 1 Felony",
+          "Disposition_description": "Superceded by Direct Indictment",
+          "Disposition_date": null,
+          "Sentence_duration": null
+        }
+      ]
     }
   ]
 }

--- a/spec/fixtures/cook_county_empty.json
+++ b/spec/fixtures/cook_county_empty.json
@@ -1,0 +1,1 @@
+{"IR_number":"asldfkjasdf","CaseDetails":[]}

--- a/spec/lib/cgla_case_chart_assister/models/arrest_spec.rb
+++ b/spec/lib/cgla_case_chart_assister/models/arrest_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe CglaCaseChartAssister::Arrest do
     it 'makes attributes available on instance' do
       event = CglaCaseChartAssister::Arrest.new(
           index: 1,
-          central_booking_number: 'booking-num',
           case_number: 'case12345',
           date_filed: '15-Oct-2019',
           arresting_agency_code: 'arrest-123',
@@ -26,7 +25,6 @@ RSpec.describe CglaCaseChartAssister::Arrest do
       )
 
       expect(event.index).to eq(1)
-      expect(event.central_booking_number).to eq('booking-num')
       expect(event.case_number).to eq('case12345')
       expect(event.date_filed).to eq('15-Oct-2019')
       expect(event.arresting_agency_code).to eq('arrest-123')

--- a/spec/lib/cgla_case_chart_assister/models/arrest_spec.rb
+++ b/spec/lib/cgla_case_chart_assister/models/arrest_spec.rb
@@ -3,9 +3,39 @@ require 'cgla_case_chart_assister/models/arrest'
 RSpec.describe CglaCaseChartAssister::Arrest do
   let(:arrest) {CglaCaseChartAssister::Arrest.new}
 
-  describe "type" do
-    it 'returns :arrest' do
-      expect(arrest.type).to eq(:arrest)
+  describe 'attributes' do
+    it 'has default attributes' do
+      event = CglaCaseChartAssister::Arrest.new
+
+      expect(event.dispositions).to match_array([])
+    end
+
+    it 'makes attributes available on instance' do
+      event = CglaCaseChartAssister::Arrest.new(
+          index: 1,
+          central_booking_number: 'booking-num',
+          case_number: 'case12345',
+          date_filed: '15-Oct-2019',
+          arresting_agency_code: 'arrest-123',
+          dcn: 'dcn123',
+          code: 'statute 1',
+          description: 'my charge',
+          offense_type: 'felony',
+          offense_class: 'class 4',
+          dispositions: ['foo']
+      )
+
+      expect(event.index).to eq(1)
+      expect(event.central_booking_number).to eq('booking-num')
+      expect(event.case_number).to eq('case12345')
+      expect(event.date_filed).to eq('15-Oct-2019')
+      expect(event.arresting_agency_code).to eq('arrest-123')
+      expect(event.dcn).to eq('dcn123')
+      expect(event.code).to eq('statute 1')
+      expect(event.description).to eq('my charge')
+      expect(event.offense_type).to eq('felony')
+      expect(event.offense_class).to eq('class 4')
+      expect(event.dispositions.count).to eq(1)
     end
   end
 

--- a/spec/lib/cgla_case_chart_assister/models/charge_spec.rb
+++ b/spec/lib/cgla_case_chart_assister/models/charge_spec.rb
@@ -4,34 +4,70 @@ require 'cgla_case_chart_assister/models/charge'
 require 'cgla_case_chart_assister/models/disposition'
 
 RSpec.describe CglaCaseChartAssister::Charge do
-  let(:event) {CglaCaseChartAssister::Charge.new(dcn: 'L6748494', case_number: '2007-CM-000747')}
+  describe 'attributes' do
+    it 'has default attributes' do
+      event = CglaCaseChartAssister::Charge.new
 
-  describe "type" do
-    it 'returns :charge' do
-      expect(event.type).to eq(:charge)
+      expect(event.dispositions).to match_array([])
+    end
+
+    it 'makes attributes available on instance' do
+      event = CglaCaseChartAssister::Charge.new(
+        index: 1,
+        central_booking_number: 'booking-num',
+        case_number: 'case12345',
+        date_filed: '15-Oct-2019',
+        arresting_agency_code: 'arrest-123',
+        dcn: 'dcn123',
+        code: 'statute 1',
+        description: 'my charge',
+        offense_type: 'felony',
+        offense_class: 'class 4',
+        dispositions: ['foo']
+      )
+
+      expect(event.index).to eq(1)
+      expect(event.central_booking_number).to eq('booking-num')
+      expect(event.case_number).to eq('case12345')
+      expect(event.date_filed).to eq('15-Oct-2019')
+      expect(event.arresting_agency_code).to eq('arrest-123')
+      expect(event.dcn).to eq('dcn123')
+      expect(event.code).to eq('statute 1')
+      expect(event.description).to eq('my charge')
+      expect(event.offense_type).to eq('felony')
+      expect(event.offense_class).to eq('class 4')
+      expect(event.dispositions.count).to eq(1)
     end
   end
 
   describe '#pending_case?' do
     it 'returns true when neither disposition nor disposition date are populated' do
-      event.dispositions = [CglaCaseChartAssister::Disposition.new(description: nil, date: nil)]
+      event = CglaCaseChartAssister::Charge.new(
+        dispositions: [CglaCaseChartAssister::Disposition.new(description: nil, date: nil)]
+      )
       expect(event.pending_case?).to eq(true)
     end
 
     it 'returns false when disposition or disposition_date or both are populated' do
-      event.dispositions = [CglaCaseChartAssister::Disposition.new(description: 'disposition', date: Date.today)]
+      event = CglaCaseChartAssister::Charge.new(
+        dispositions: [CglaCaseChartAssister::Disposition.new(description: 'disposition', date: Date.today)]
+      )
       expect(event.pending_case?).to eq(false)
     end
   end
 
   describe 'pre_JANO?' do
     it 'returns true when the disposition is pre-JANO' do
-      event.dispositions = [CglaCaseChartAssister::Disposition.new(description: 'Pre-JANO Disposition')]
+      event = CglaCaseChartAssister::Charge.new(
+        dispositions: [CglaCaseChartAssister::Disposition.new(description: 'Pre-JANO Disposition')]
+      )
       expect(event.pre_JANO?).to eq(true)
     end
 
     it 'returns false when the disposition is anything else' do
-      event.dispositions = [CglaCaseChartAssister::Disposition.new(description: 'blah')]
+      event = CglaCaseChartAssister::Charge.new(
+        dispositions: [CglaCaseChartAssister::Disposition.new(description: 'blah')]
+      )
       expect(event.pre_JANO?).to eq(false)
     end
   end
@@ -53,46 +89,62 @@ RSpec.describe CglaCaseChartAssister::Charge do
     end
 
     it 'returns false if the disposition description is empty' do
-      event.dispositions = [CglaCaseChartAssister::Disposition.new(description: nil)]
+      event = CglaCaseChartAssister::Charge.new(
+        dispositions: [CglaCaseChartAssister::Disposition.new(description: nil)]
+      )
       expect(event.dismissed?).to eq(false)
     end
 
     it 'returns false when the disposition description is anything else' do
-      event.dispositions = [CglaCaseChartAssister::Disposition.new(description: 'my fake disposition')]
+      event = CglaCaseChartAssister::Charge.new(
+        dispositions: [CglaCaseChartAssister::Disposition.new(description: 'my fake disposition')]
+      )
       expect(event.dismissed?).to eq(false)
     end
   end
 
   describe 'acquitted?' do
     it 'returns true when the disposition is Not Guilty' do
-      event.dispositions = [CglaCaseChartAssister::Disposition.new(description: 'Not Guilty')]
+      event = CglaCaseChartAssister::Charge.new(
+        dispositions: [CglaCaseChartAssister::Disposition.new(description: 'Not Guilty')]
+      )
       expect(event.acquitted?).to eq(true)
     end
 
     it 'returns false if the disposition description is empty' do
-      event.dispositions = [CglaCaseChartAssister::Disposition.new(description: nil)]
+      event = CglaCaseChartAssister::Charge.new(
+        dispositions: [CglaCaseChartAssister::Disposition.new(description: nil)]
+      )
       expect(event.dismissed?).to eq(false)
     end
 
     it 'returns false when the disposition is anything else' do
-      event.dispositions = [CglaCaseChartAssister::Disposition.new(description: 'my fake disposition')]
+      event = CglaCaseChartAssister::Charge.new(
+        dispositions: [CglaCaseChartAssister::Disposition.new(description: 'my fake disposition')]
+      )
       expect(event.acquitted?).to eq(false)
     end
   end
 
   describe 'conviction?' do
     it 'returns true when the disposition is Guilty' do
-      event.dispositions = [CglaCaseChartAssister::Disposition.new(description: 'Guilty')]
+      event = CglaCaseChartAssister::Charge.new(
+        dispositions: [CglaCaseChartAssister::Disposition.new(description: 'Guilty')]
+      )
       expect(event.conviction?).to eq(true)
     end
 
     it 'returns false if the disposition description is empty' do
-      event.dispositions = [CglaCaseChartAssister::Disposition.new(description: nil)]
+      event = CglaCaseChartAssister::Charge.new(
+        dispositions: [CglaCaseChartAssister::Disposition.new(description: nil)]
+      )
       expect(event.dismissed?).to eq(false)
     end
 
     it 'returns false when the disposition is anything else' do
-      event.dispositions = [CglaCaseChartAssister::Disposition.new(description: 'my fake disposition')]
+      event = CglaCaseChartAssister::Charge.new(
+        dispositions: [CglaCaseChartAssister::Disposition.new(description: 'my fake disposition')]
+      )
       expect(event.conviction?).to eq(false)
     end
   end

--- a/spec/lib/cgla_case_chart_assister/models/charge_spec.rb
+++ b/spec/lib/cgla_case_chart_assister/models/charge_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe CglaCaseChartAssister::Charge do
     it 'makes attributes available on instance' do
       event = CglaCaseChartAssister::Charge.new(
         index: 1,
-        central_booking_number: 'booking-num',
         case_number: 'case12345',
         date_filed: '15-Oct-2019',
         arresting_agency_code: 'arrest-123',
@@ -27,7 +26,6 @@ RSpec.describe CglaCaseChartAssister::Charge do
       )
 
       expect(event.index).to eq(1)
-      expect(event.central_booking_number).to eq('booking-num')
       expect(event.case_number).to eq('case12345')
       expect(event.date_filed).to eq('15-Oct-2019')
       expect(event.arresting_agency_code).to eq('arrest-123')

--- a/spec/lib/cgla_case_chart_assister/models/court_case_spec.rb
+++ b/spec/lib/cgla_case_chart_assister/models/court_case_spec.rb
@@ -12,10 +12,12 @@ RSpec.describe CglaCaseChartAssister::CourtCase do
 
     it 'makes attributes available on instance' do
       event = CglaCaseChartAssister::CourtCase.new(
+        person_name: 'Person McPerson',
         case_number: 'case12345',
         charges: ['foo']
       )
 
+      expect(event.person_name).to eq('Person McPerson')
       expect(event.case_number).to eq('case12345')
       expect(event.charges.count).to eq(1)
     end

--- a/spec/lib/cgla_case_chart_assister/models/court_case_spec.rb
+++ b/spec/lib/cgla_case_chart_assister/models/court_case_spec.rb
@@ -3,11 +3,24 @@ require 'cgla_case_chart_assister/models/charge'
 require 'cgla_case_chart_assister/models/disposition'
 
 RSpec.describe CglaCaseChartAssister::CourtCase do
-  describe 'type' do
-    it 'returns :court_case' do
-      expect(CglaCaseChartAssister::CourtCase.new.type).to eq(:court_case)
+  describe 'attributes' do
+    it 'has default attributes' do
+      event = CglaCaseChartAssister::CourtCase.new
+
+      expect(event.charges).to match_array([])
+    end
+
+    it 'makes attributes available on instance' do
+      event = CglaCaseChartAssister::CourtCase.new(
+        case_number: 'case12345',
+        charges: ['foo']
+      )
+
+      expect(event.case_number).to eq('case12345')
+      expect(event.charges.count).to eq(1)
     end
   end
+
 
   describe 'all_expungable?' do
     context 'when all the charges are dismissals or acquittals' do

--- a/spec/lib/cgla_case_chart_assister/models/court_case_spec.rb
+++ b/spec/lib/cgla_case_chart_assister/models/court_case_spec.rb
@@ -14,11 +14,13 @@ RSpec.describe CglaCaseChartAssister::CourtCase do
       event = CglaCaseChartAssister::CourtCase.new(
         person_name: 'Person McPerson',
         case_number: 'case12345',
+        central_booking_number: 'booking1234',
         charges: ['foo']
       )
 
       expect(event.person_name).to eq('Person McPerson')
       expect(event.case_number).to eq('case12345')
+      expect(event.central_booking_number).to eq('booking1234')
       expect(event.charges.count).to eq(1)
     end
   end

--- a/spec/lib/cgla_case_chart_assister/models/disposition_spec.rb
+++ b/spec/lib/cgla_case_chart_assister/models/disposition_spec.rb
@@ -1,11 +1,20 @@
 require 'cgla_case_chart_assister/models/disposition'
 
 RSpec.describe CglaCaseChartAssister::Disposition do
-  let(:disposition) {CglaCaseChartAssister::Disposition.new}
-
-  describe 'type' do
-    it 'returns :disposition' do
-      expect(disposition.type).to eq(:disposition)
-    end
+  it 'makes attributes available on instance' do
+    disposition = CglaCaseChartAssister::Disposition.new(
+      case_number: 'case1235',
+      charge_index: '1',
+      description: 'Final disposition',
+      date: '15-Oct-2005',
+      sentence_description: 'A sentence',
+      sentence_duration: '5 years'
+    )
+    expect(disposition.case_number).to eq('case1235')
+    expect(disposition.charge_index).to eq('1')
+    expect(disposition.description).to eq('Final disposition')
+    expect(disposition.date).to eq('15-Oct-2005')
+    expect(disposition.sentence_description).to eq('A sentence')
+    expect(disposition.sentence_duration).to eq('5 years')
   end
 end

--- a/spec/lib/cgla_case_chart_assister/models/history_spec.rb
+++ b/spec/lib/cgla_case_chart_assister/models/history_spec.rb
@@ -3,29 +3,49 @@ require 'cgla_case_chart_assister/models/disposition'
 require 'cgla_case_chart_assister/models/history'
 
 RSpec.describe CglaCaseChartAssister::History do
-  let(:history) {CglaCaseChartAssister::History.new}
+  describe 'attributes' do
+    it 'has default attributes' do
+      history = CglaCaseChartAssister::History.new
 
-  describe 'type' do
-    it 'returns :history' do
-      expect(history.type).to eq(:history)
+      expect(history.events).to match_array([])
+      expect(history.court_cases).to match_array([])
+    end
+
+    it 'makes attributes available on instance' do
+      history = CglaCaseChartAssister::History.new(
+        person_name: 'jane doe',
+        ir_number: '1234',
+        dob: '12-Oct-2005',
+        events: ['fake event'],
+        court_cases: ['fake case one', 'fake case two']
+      )
+
+      expect(history.person_name).to eq('jane doe')
+      expect(history.ir_number).to eq('1234')
+      expect(history.dob).to eq('12-Oct-2005')
+      expect(history.events.count).to eq(1)
+      expect(history.court_cases.count).to eq(2)
     end
   end
 
   describe 'has_pending_case?' do
     context 'when any charge is pending' do
       it' returns true' do
-        history.events = [CglaCaseChartAssister::Charge.new(dispositions: [])]
+        history = CglaCaseChartAssister::History.new(events: [
+          CglaCaseChartAssister::Charge.new(dispositions: [])
+        ])
 
         expect(history.has_pending_case?).to eq(true)
       end
     end
 
-
     context 'when any charge is pending' do
       it' returns true' do
-        history.events = [CglaCaseChartAssister::Charge.new(dispositions: [
-          CglaCaseChartAssister::Disposition.new(description: nil, date: nil)
-        ])]
+        history = CglaCaseChartAssister::History.new(events: [
+          CglaCaseChartAssister::Charge.new(dispositions: [
+            CglaCaseChartAssister::Disposition.new(description: nil, date: nil)
+          ])
+        ])
 
         expect(history.has_pending_case?).to eq(true)
       end

--- a/spec/lib/cgla_case_chart_assister/parsers/champaign_county_parser_spec.rb
+++ b/spec/lib/cgla_case_chart_assister/parsers/champaign_county_parser_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CglaCaseChartAssister::ChampaignCountyParser do
         }
         event = CglaCaseChartAssister::ChampaignCountyParser.parse_event(fake_row, 3)
 
-        expect(event.type).to eq(:charge)
+        expect(event).to be_a(CglaCaseChartAssister::Charge)
         expect(event.index).to eq(3)
         expect(event.central_booking_number).to eq(nil)
         expect(event.case_number).to eq('2007-CM-000747')
@@ -70,7 +70,7 @@ RSpec.describe CglaCaseChartAssister::ChampaignCountyParser do
         }
         event = CglaCaseChartAssister::ChampaignCountyParser.parse_event(fake_row, 3)
 
-        expect(event.type).to eq(:arrest)
+        expect(event).to be_a(CglaCaseChartAssister::Arrest)
         expect(event.index).to eq(3)
         expect(event.central_booking_number).to eq(nil)
         expect(event.case_number).to eq(nil)
@@ -81,7 +81,7 @@ RSpec.describe CglaCaseChartAssister::ChampaignCountyParser do
         expect(event.description).to eq('Knowingly Damage Prop<$300')
         expect(event.offense_type).to eq(nil)
         expect(event.offense_class).to eq(nil)
-        expect(event.dispositions).to eq(nil)
+        expect(event.dispositions.count).to eq(0)
       end
     end
 
@@ -285,9 +285,8 @@ RSpec.describe CglaCaseChartAssister::ChampaignCountyParser do
       expect(history.ir_number).to eq(nil)
       expect(history.dob).to eq('02-May-85')
       expect(history.events.length).to eq(2)
-      expect(history.events.first.type).to eq(:charge)
+      expect(history.events.first).to be_a(CglaCaseChartAssister::Charge)
       expect(history.court_cases.length).to eq(1)
-      expect(history.court_cases.first.type).to eq(:court_case)
       expect(history.court_cases.first.case_number).to eq('2007-CM-000747')
     end
 

--- a/spec/lib/cgla_case_chart_assister/parsers/champaign_county_parser_spec.rb
+++ b/spec/lib/cgla_case_chart_assister/parsers/champaign_county_parser_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe CglaCaseChartAssister::ChampaignCountyParser do
 
         expect(event).to be_a(CglaCaseChartAssister::Charge)
         expect(event.index).to eq(3)
-        expect(event.central_booking_number).to eq(nil)
         expect(event.case_number).to eq('2007-CM-000747')
         expect(event.date_filed).to eq('05-Jul-2007')
         expect(event.arresting_agency_code).to eq('Toon County Sheriff')
@@ -72,7 +71,6 @@ RSpec.describe CglaCaseChartAssister::ChampaignCountyParser do
 
         expect(event).to be_a(CglaCaseChartAssister::Arrest)
         expect(event.index).to eq(3)
-        expect(event.central_booking_number).to eq(nil)
         expect(event.case_number).to eq(nil)
         expect(event.date_filed).to eq('05-Jul-2007')
         expect(event.arresting_agency_code).to eq('Toon County Sheriff')

--- a/spec/lib/cgla_case_chart_assister/parsers/cook_county_parser_spec.rb
+++ b/spec/lib/cgla_case_chart_assister/parsers/cook_county_parser_spec.rb
@@ -43,10 +43,13 @@ RSpec.describe CglaCaseChartAssister::CookCountyParser do
 
       expect(court_cases.length).to eq(4)
       expect(court_cases[0].case_number).to eq('00CR1234567')
+      expect(court_cases[0].person_name).to eq('DOE, JOHN')
       expect(court_cases[0].charges.length).to eq(2)
       expect(court_cases[1].case_number).to eq('14CR0123456')
+      expect(court_cases[1].person_name).to eq('DOE, JOHN')
       expect(court_cases[1].charges.length).to eq(2)
       expect(court_cases[2].case_number).to eq('95CR0127401')
+      expect(court_cases[2].person_name).to eq('DOE, JOHN')
       expect(court_cases[2].charges.length).to eq(1)
     end
   end

--- a/spec/lib/cgla_case_chart_assister/parsers/cook_county_parser_spec.rb
+++ b/spec/lib/cgla_case_chart_assister/parsers/cook_county_parser_spec.rb
@@ -7,17 +7,32 @@ RSpec.describe CglaCaseChartAssister::CookCountyParser do
   let(:cook_json) { JSON.parse(FixtureHelper.read_fixture('./spec/fixtures/cook_county.json')) }
 
   describe 'parse_history' do
-    it 'returns a History that contains an Event of each analyzable row provided and corresponding CourtCases' do
-      history = CglaCaseChartAssister::CookCountyParser.parse_history(cook_json)
+    context 'when case details are present' do
+      it 'returns a History that contains an Event of each analyzable row provided and corresponding CourtCases' do
+        history = CglaCaseChartAssister::CookCountyParser.parse_history(cook_json)
 
-      expect(history.person_name).to eq('DOE, JOHN')
-      expect(history.ir_number).to eq('5555555')
-      expect(history.dob).to eq(Date.parse('1970-01-03'))
-      expect(history.events.length).to eq(5)
-      expect(history.events.first.type).to eq(:charge)
-      expect(history.court_cases.length).to eq(3)
-      expect(history.court_cases.first.type).to eq(:court_case)
-      expect(history.court_cases.first.case_number).to eq('00CR1234567')
+        expect(history.person_name).to eq('DOE, JOHN')
+        expect(history.ir_number).to eq('5555555')
+        expect(history.dob).to eq(Date.parse('1970-01-03'))
+        expect(history.events.length).to eq(5)
+        expect(history.events.first).to be_a(CglaCaseChartAssister::Charge)
+        expect(history.court_cases.length).to eq(3)
+        expect(history.court_cases.first.case_number).to eq('00CR1234567')
+      end
+    end
+
+    context 'when case details are not present' do
+      let(:cook_json) { JSON.parse(FixtureHelper.read_fixture('./spec/fixtures/cook_county_empty.json')) }
+
+      it 'returns a History with empty information' do
+        history = CglaCaseChartAssister::CookCountyParser.parse_history(cook_json)
+
+        expect(history.person_name).to eq(nil)
+        expect(history.ir_number).to eq('asldfkjasdf')
+        expect(history.dob).to eq(nil)
+        expect(history.events.length).to eq(0)
+        expect(history.court_cases.length).to eq(0)
+      end
     end
   end
 

--- a/spec/lib/cgla_case_chart_assister/parsers/cook_county_parser_spec.rb
+++ b/spec/lib/cgla_case_chart_assister/parsers/cook_county_parser_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe CglaCaseChartAssister::CookCountyParser do
       charges = CglaCaseChartAssister::CookCountyParser.parse_charges(charge_details, case_number: '00CR1234567')
 
       expect(charges.length).to eq(2)
-      expect(charges.all?{|c| c.type == :charge}).to eq(true)
+      expect(charges.all?{|c| c.is_a?(CglaCaseChartAssister::Charge) }).to eq(true)
 
       expect(charges[0].index).to eq('1')
       expect(charges[0].case_number).to eq('00CR1234567')

--- a/spec/lib/cgla_case_chart_assister/parsers/cook_county_parser_spec.rb
+++ b/spec/lib/cgla_case_chart_assister/parsers/cook_county_parser_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe CglaCaseChartAssister::CookCountyParser do
         expect(history.person_name).to eq('DOE, JOHN')
         expect(history.ir_number).to eq('5555555')
         expect(history.dob).to eq(Date.parse('1970-01-03'))
-        expect(history.events.length).to eq(5)
+        expect(history.events.length).to eq(6)
         expect(history.events.first).to be_a(CglaCaseChartAssister::Charge)
-        expect(history.court_cases.length).to eq(3)
+        expect(history.court_cases.length).to eq(4)
         expect(history.court_cases.first.case_number).to eq('00CR1234567')
       end
     end
@@ -41,7 +41,7 @@ RSpec.describe CglaCaseChartAssister::CookCountyParser do
     it 'creates a court case for each case number' do
       court_cases = CglaCaseChartAssister::CookCountyParser.parse_court_cases(case_details)
 
-      expect(court_cases.length).to eq(3)
+      expect(court_cases.length).to eq(4)
       expect(court_cases[0].case_number).to eq('00CR1234567')
       expect(court_cases[0].charges.length).to eq(2)
       expect(court_cases[1].case_number).to eq('14CR0123456')
@@ -68,7 +68,7 @@ RSpec.describe CglaCaseChartAssister::CookCountyParser do
       expect(charges[0].offense_class).to eq(nil)
       expect(charges[0].dispositions.length).to eq(1)
       expect(charges[0].dispositions.first.description).to eq(nil)
-      expect(charges[0].dispositions.first.date).to eq(Date.parse('2000-10-18'))
+      expect(charges[0].dispositions.first.date).to eq(DateTime.new(2000,10,18,0,0,0))
       expect(charges[0].dispositions.first.sentence_description).to eq('Probation')
       expect(charges[0].dispositions.first.sentence_duration).to eq('0')
 
@@ -81,7 +81,7 @@ RSpec.describe CglaCaseChartAssister::CookCountyParser do
       expect(charges[1].offense_class).to eq('4')
       expect(charges[1].dispositions.length).to eq(3)
       expect(charges[1].dispositions.first.description).to eq('Finding of Guilty')
-      expect(charges[1].dispositions.first.date).to eq(Date.parse('2000-10-18'))
+      expect(charges[1].dispositions.first.date).to eq(DateTime.new(2000,10,18,0,0,0))
       expect(charges[1].dispositions.first.sentence_description).to eq('Probation')
       expect(charges[1].dispositions.first.sentence_duration).to eq('0')
     end

--- a/spec/lib/cgla_case_chart_assister/parsers/cook_county_parser_spec.rb
+++ b/spec/lib/cgla_case_chart_assister/parsers/cook_county_parser_spec.rb
@@ -44,12 +44,15 @@ RSpec.describe CglaCaseChartAssister::CookCountyParser do
       expect(court_cases.length).to eq(4)
       expect(court_cases[0].case_number).to eq('00CR1234567')
       expect(court_cases[0].person_name).to eq('DOE, JOHN')
+      expect(court_cases[0].central_booking_number).to eq('0123456789')
       expect(court_cases[0].charges.length).to eq(2)
       expect(court_cases[1].case_number).to eq('14CR0123456')
       expect(court_cases[1].person_name).to eq('DOE, JOHN')
+      expect(court_cases[1].central_booking_number).to eq('018000000')
       expect(court_cases[1].charges.length).to eq(2)
       expect(court_cases[2].case_number).to eq('95CR0127401')
       expect(court_cases[2].person_name).to eq('DOE, JOHN')
+      expect(court_cases[2].central_booking_number).to eq('9876543')
       expect(court_cases[2].charges.length).to eq(1)
     end
   end


### PR DESCRIPTION
This pull requests gets our gem working with the latest production data in our web application.

As part of this, it makes the following changes to work with the data structure we're receiving:
* Convert all structs to classes
    Now that we're using the gem in a host application, it looks like it would be useful to have defaults for certain model attributes (empty arrays, for example). This is difficult in structs, so this commit converts all existing structs into classes. It also creates an abstract Event model from which our Charge and Arrest events can descend (more closely expresses how we designed them!).
* Add support for Cook IR number with no cases
* Support nil disposition description
* Add person_name to CourtCase
    In CookCounty, we receive names at the court case level. This makes that information available on the data model.
* Move central_booking_number to CourtCase
    Arrests and charges won't have a central booking number -- only court cases should (and that's how it's being returned in the Cook County data). Champaign is not using CBNs, so we're safe to move.


As a next step, it might be nice nice to add some parsing exception handling